### PR TITLE
Bump scout version to 5.6.0 for default attributes.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ default['scout']['home'] = "/home/#{node['scout']['user']}"
 default['scout']['gem_packages']
 default['scout']['rvm_ruby_string'] = nil
 default['scout']['rvm_wrapper_prefix'] = "scout"
-default['scout']['version'] = "5.5.4"
+default['scout']['version'] = "5.6.0"
 
 default['scout']['key'] = nil
 default['scout']['name'] = nil


### PR DESCRIPTION
As the newer version of gem released, I think it's time for this cookbook to upgrade the default attribute to use latest version of scout client.
